### PR TITLE
Call API over https rather than http

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = class Wolfram extends Plugin {
                     };
                 }
 
-                let url = `http://api.wolframalpha.com/v1/result?appid=${appID}&i=${encodeURIComponent(input)}&units=metric`;
+                let url = `https://api.wolframalpha.com/v1/result?appid=${appID}&i=${encodeURIComponent(input)}&units=metric`;
                 let res = await get(url)
 
                 if (res.statusCode == 200) {


### PR DESCRIPTION
Both more secure and, for me at least, using http failed 90% of the time