### PR TITLE
feat: better error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,10 +46,7 @@ module.exports = class Wolfram extends Plugin {
                         };
                     }
 
-                    return {
-                        send: false,
-                        result: `Unknown failure.`
-                    };
+                    throw new Error(res.body ? res.body.toString() : `Unknown error with code ${res.statusCode}`)
                 } catch (err) {
                     const error = err instanceof Error ? err.toString() : String(err)
 


### PR DESCRIPTION
Unlike `fetch`, `http.get` actually throws an error, so it remains uncaught if the status code is not in the 200s, leaving the error in the console without any output in the Discord UI.

This PR catches the HTTP errors (usually `501 Not Implemented`) and displays it to the user instead of leaving them hanging.